### PR TITLE
AssemblyWidget U/X change.

### DIFF
--- a/src/assemblyWidget.js
+++ b/src/assemblyWidget.js
@@ -14,7 +14,7 @@ class AssemblyWidget {
 
         this.genomicService = genomicService;
 
-        raycastService.registerClickHandler(this.raycastClickHandler.bind(this));
+        // raycastService.registerClickHandler(this.raycastClickHandler.bind(this));
 
         this.restoreUnsub = eventBus.subscribe('assembly:restoreEmphasis', data => {
             const selectors = Array.from(this.listGroup.querySelectorAll('.assembly-widget__genome-selector'))


### PR DESCRIPTION
When the user selects an assembly via the widget, previous user interaction supported the user clicking anywhere onscreen to deselect. That behavior has been removed.